### PR TITLE
Added more specifics on auto re-exports

### DIFF
--- a/markdown/guide/sharing-components-and-more.md
+++ b/markdown/guide/sharing-components-and-more.md
@@ -29,4 +29,4 @@ module.exports = EngineAddon.extend({
 });
 ```
 
-That's it! Now, any addon included in your package.json file will automatically get included in your Engine.
+That's it! Now, any addon included in your package.json `dependencies` key will automatically get included in your Engine. 


### PR DESCRIPTION
This might be obvious but at the same time might help clearing the path when "things don't work" -- i.e. when you forgot to move your dep from `devDependencies` and expect the auto re-export to work.